### PR TITLE
Fix hour cycle of now local date-time

### DIFF
--- a/src/localDateTime.ts
+++ b/src/localDateTime.ts
@@ -49,7 +49,7 @@ export class LocalDateTime {
         const now = new Date().toLocaleString('en-US', {
             timeZone: zone.getId(),
             calendar: 'iso8601',
-            hour12: false,
+            hourCycle: 'h23',
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',

--- a/test/localDateTime.test.ts
+++ b/test/localDateTime.test.ts
@@ -53,14 +53,20 @@ describe('A value object representing a local date time', () => {
         expect(localDateTime.getNano()).toBe(0);
     });
 
-    it('can provide the current local date time from the system clock in a given time zone', () => {
-        jest.useFakeTimers()
-            .setSystemTime(new Date('2015-08-31T12:11:59.123456789Z').getTime());
+    it.each([
+        ['2015-08-31T12:11:59.123456789Z', TimeZone.of('America/Sao_Paulo'), '2015-08-31T09:11:59.123'],
+        ['2015-08-31T00:00:00.123456789Z', TimeZone.of('UTC'), '2015-08-31T00:00:00.123'],
+    ])(
+        'can provide the current local date time from the system clock in a given time zone',
+        (currentTime: string, timeZone: TimeZone, localDateTime: string) => {
+            jest.useFakeTimers()
+                .setSystemTime(new Date(currentTime).getTime());
 
-        const now = LocalDateTime.now(TimeZone.of('America/Sao_Paulo'));
+            const now = LocalDateTime.now(timeZone);
 
-        expect(now.toString()).toBe('2015-08-31T09:11:59.123');
-    });
+            expect(now.toString()).toBe(localDateTime);
+        },
+    );
 
     it('should parse a valid ISO-8601 date time', () => {
         const dateTime = '2015-08-30T14:20:05.123';


### PR DESCRIPTION
## Summary
This PR fixes the hour cycle of `toLocaleString` from 1-24 to 0-23.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings