### PR TITLE
Remove external dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,8 @@
     "": {
       "name": "@croct-tech/time",
       "version": "0.0.0-dev",
-      "dependencies": {
-        "@vvo/tzdb": "^6.68.0",
-        "date-fns-tz": "^1.3.7"
-      },
       "devDependencies": {
         "@croct/eslint-plugin": "^0.6.2",
-        "@types/date-fns": "^2.6.0",
         "@types/jest": "^27.4",
         "@types/uuid": "^8.3",
         "@typescript-eslint/parser": "^5.17",
@@ -1232,16 +1227,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/date-fns": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@types/date-fns/-/date-fns-2.6.0.tgz",
-      "integrity": "sha512-9DSw2ZRzV0Tmpa6PHHJbMcZn79HHus+BBBohcOaDzkK/G3zMjDUDYjJIWBFLbkh+1+/IOS0A59BpQfdr37hASg==",
-      "deprecated": "This is a stub types definition for date-fns (https://github.com/date-fns/date-fns). date-fns provides its own type definitions, so you don't need @types/date-fns installed!",
-      "dev": true,
-      "dependencies": {
-        "date-fns": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1538,11 +1523,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
-    },
-    "node_modules/@vvo/tzdb": {
-      "version": "6.68.0",
-      "resolved": "https://registry.npmjs.org/@vvo/tzdb/-/tzdb-6.68.0.tgz",
-      "integrity": "sha512-gTYX0c/zfvdeywLFZdHJzxczXjZf4oZHRnkTemziyn4p0R+qoqdrRK5PqY2DFnH64YkFcpreNS1JbbnfWiMQgQ=="
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -2209,26 +2189,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -4733,9 +4693,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -6123,9 +6083,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -7455,15 +7415,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/date-fns": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@types/date-fns/-/date-fns-2.6.0.tgz",
-      "integrity": "sha512-9DSw2ZRzV0Tmpa6PHHJbMcZn79HHus+BBBohcOaDzkK/G3zMjDUDYjJIWBFLbkh+1+/IOS0A59BpQfdr37hASg==",
-      "dev": true,
-      "requires": {
-        "date-fns": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -7661,11 +7612,6 @@
         "@typescript-eslint/types": "5.17.0",
         "eslint-visitor-keys": "^3.0.0"
       }
-    },
-    "@vvo/tzdb": {
-      "version": "6.68.0",
-      "resolved": "https://registry.npmjs.org/@vvo/tzdb/-/tzdb-6.68.0.tgz",
-      "integrity": "sha512-gTYX0c/zfvdeywLFZdHJzxczXjZf4oZHRnkTemziyn4p0R+qoqdrRK5PqY2DFnH64YkFcpreNS1JbbnfWiMQgQ=="
     },
     "abab": {
       "version": "2.0.5",
@@ -8169,17 +8115,6 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
-    },
-    "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
-    },
-    "date-fns-tz": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
-      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
-      "requires": {}
     },
     "debug": {
       "version": "4.3.4",
@@ -10047,9 +9982,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsx-ast-utils": {
@@ -11071,9 +11006,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@croct/eslint-plugin": "^0.6.2",
-    "@types/date-fns": "^2.6.0",
     "@types/jest": "^27.4",
     "@types/uuid": "^8.3",
     "@typescript-eslint/parser": "^5.17",
@@ -45,9 +44,5 @@
   "files": [
     "**/*.js",
     "**/*.ts"
-  ],
-  "dependencies": {
-    "@vvo/tzdb": "^6.68.0",
-    "date-fns-tz": "^1.3.7"
-  }
+  ]
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,5 @@
+declare namespace Intl {
+    type Key = 'calendar' | 'collation' | 'currency' | 'numberingSystem' | 'timeZone' | 'unit';
+
+    function supportedValuesOf(input: Key): string[];
+}

--- a/src/timeZone.ts
+++ b/src/timeZone.ts
@@ -1,13 +1,11 @@
-import {timeZonesNames} from '@vvo/tzdb';
-
-const timeZoneIds = timeZonesNames.concat('UTC');
-
 /**
  * A time-zone ID, such as Europe/Paris.
  */
 export class TimeZone {
+    private static SUPPORTED_TIMEZONE_IDS: ReadonlySet<string>;
+
     /**
-     * The UTC timezone.
+     * The UTC time zone.
      */
     public static readonly UTC = new TimeZone('UTC');
 
@@ -26,19 +24,26 @@ export class TimeZone {
     /**
      * Returns the list of supported time zones.
      */
-    public static getTimesZoneIds(): string[] {
-        return timeZoneIds;
+    public static getTimesZoneIds(): ReadonlySet<string> {
+        if (TimeZone.SUPPORTED_TIMEZONE_IDS === undefined) {
+            TimeZone.SUPPORTED_TIMEZONE_IDS = new Set([
+                'UTC',
+                ...Intl.supportedValuesOf('timeZone'),
+            ]);
+        }
+
+        return TimeZone.SUPPORTED_TIMEZONE_IDS;
     }
 
     /**
-     * Creates a timezone from its ID.
+     * Creates a time zone from its ID.
      *
-     * @param id The timezone ID.
+     * @param id The time zone ID.
      *
-     * @throws {Error} If the timezone ID is not supported.
+     * @throws {Error} If the time zone ID is not supported.
      */
     public static of(id: string): TimeZone {
-        if (TimeZone.getTimesZoneIds().indexOf(id) === -1) {
+        if (!TimeZone.getTimesZoneIds().has(id)) {
             throw new Error(`The timezone ${id} is not supported.`);
         }
 
@@ -46,28 +51,28 @@ export class TimeZone {
     }
 
     /**
-     * Returns the timezone ID.
+     * Returns the time zone ID.
      */
     public getId(): string {
         return this.id;
     }
 
     /**
-     * Returns the string representation of the timezone.
+     * Returns the string representation of the time zone.
      */
     public toString(): string {
         return this.id;
     }
 
     /**
-     * Checks if the timezone is equal to another timezone.
+     * Checks if the time zone is equal to another time zone.
      */
     public equals(other: TimeZone): boolean {
         return this.id === other.id;
     }
 
     /**
-     * Returns the JSON representation of the timezone.
+     * Returns the JSON representation of the time zone.
      */
     public toJSON(): string {
         return this.toString();

--- a/test/localDateTime.test.ts
+++ b/test/localDateTime.test.ts
@@ -75,16 +75,48 @@ describe('A value object representing a local date time', () => {
         expect(localDateTime.toString()).toBe(dateTime);
     });
 
-    it.each([
-        '2015-08-30',
-        '12:34:56',
-        '2015-08-30 12:34:56',
-        '20150830123456',
-        '2015/08/30 12:34:56',
-        '2015T08-30T12:34:56',
-        'Sun Aug 30 2015 12:34:56',
-    ])('should fail to parse %s', value => {
-        expect(() => LocalDateTime.parse(value)).toThrowError('Invalid date time format.');
+    type ConversionScenario = {
+        input: LocalDateTime,
+        timeZone: TimeZone,
+        expected: string,
+    };
+
+    it.each<ConversionScenario>([
+        {
+            input: LocalDateTime.of(LocalDate.of(2018, 11, 4), LocalTime.of(0, 0, 0)),
+            timeZone: TimeZone.of('America/Sao_Paulo'),
+            // In November 4th 2018 at 00:00:00 in Sao Paulo there was a daylight saving time change
+            // from -03:00 to -02:00. The local time 00:00:00 does not exist in -02:00.
+            expected: '2018-11-04T03:00:00Z',
+        },
+        {
+            input: LocalDateTime.of(LocalDate.of(2019, 2, 16), LocalTime.of(0, 0, 0)),
+            timeZone: TimeZone.of('America/Sao_Paulo'),
+            // In February 16th 2019 at 00:00:00 in Sao Paulo there was a daylight saving time change
+            // from -02:00 to -03:00. The local time 00:00:00 occurs twice in -03:00.
+            expected: '2019-02-16T02:00:00Z',
+        },
+        {
+            input: LocalDateTime.of(LocalDate.of(2015, 8, 31), LocalTime.of(1, 2, 3, 999999999)),
+            // In August 31st 2015 at 01:02:03.999999999, the time zone offset was -03:00.
+            timeZone: TimeZone.of('America/Sao_Paulo'),
+            expected: '2015-08-31T04:02:03.999999999Z',
+        },
+        {
+            input: LocalDateTime.of(LocalDate.of(2022, 9, 25), LocalTime.of(2, 45, 0)),
+            // In September 25th 2022 at 02:45:00, the time zone offset changed from +12:45 to +13:45.
+            // 2022-09-25T03:45:00 - 13:45 = 2022-09-24T14:00:00
+            timeZone: TimeZone.of('Pacific/Chatham'),
+            expected: '2022-09-24T14:00:00Z',
+        },
+        {
+            input: LocalDateTime.of(LocalDate.of(2022, 10, 2), LocalTime.of(2, 0, 0)),
+            // In October 2nd 2022 at 02:00:00, the time zone offset changed from +11:00 to +10:30
+            timeZone: TimeZone.of('Australia/Lord_Howe'),
+            expected: '2022-10-01T15:30:00Z',
+        },
+    ])('should convert $input to $expected', ({input, timeZone, expected}) => {
+        expect(input.toInstant(timeZone).toString()).toBe(expected);
     });
 
     it('can be created from the number of seconds since the UNIX epoch', () => {
@@ -150,18 +182,6 @@ describe('A value object representing a local date time', () => {
         expect(one.equals(one)).toBe(true);
         expect(one.equals(two)).toBe(false);
         expect(one.equals(three)).toBe(true);
-    });
-
-    it('can be converted to an instant', () => {
-        const localDateTime = LocalDateTime.of(
-            LocalDate.of(2015, 8, 31),
-            LocalTime.of(12, 11, 59, 123456789),
-        );
-
-        const instant = localDateTime.toInstant(TimeZone.of('America/Sao_Paulo'));
-
-        // In 2015-08-31T12:11:59.123456789 America/Sao_Paulo was UTC-03:00
-        expect(instant.toString()).toBe('2015-08-31T15:11:59.123456789Z');
     });
 
     it('should serialize to JSON in the ISO-8601 format', () => {

--- a/test/timeZone.test.ts
+++ b/test/timeZone.test.ts
@@ -1,4 +1,3 @@
-import {timeZonesNames} from '@vvo/tzdb';
 import {TimeZone} from '../src';
 
 describe('A value object representing a timezone', () => {
@@ -14,10 +13,6 @@ describe('A value object representing a timezone', () => {
 
     it('should reject invalid timezone IDs', () => {
         expect(() => TimeZone.of('America')).toThrowError('The timezone America is not supported.');
-    });
-
-    it('should return the list of supported time zones.', () => {
-        expect(TimeZone.getTimesZoneIds()).toEqual(timeZonesNames.concat('UTC'));
     });
 
     it('can be converted to a string representation of the timezone', () => {


### PR DESCRIPTION
## Summary
This PR removes all external dependencies to reduce the bundle size and make it suitable for use in the front end.

### Context
This library currently depends on `@vvo/tzdb` and the `date-fns-tz` to overcome the current timezone limitations from the JavaScript date/time API. 

#### `@vvo/tzdb`
This dependency provides the set of timezone IDs at the cost of 132.4 kB in the bundle size. `Intl.supportedValuesOf` is the best replacement here since it adds no overhead and ensures compatibility with the `Intl.DateTimeFormat`. Modern browsers and Node 18+ already support it.

#### `date-fns-tz`
This dependency provides a timezone lookup database for converting local date times into instants, adding extra 9.2 kB to the bundle size. Efficient implementations usually perform a binary search to find the transition, which generally takes a few milliseconds.

Based on performed benchmarks, the proposed implementation handles most cases in <2ms, which is a reasonable tradeoff.

### BC-Break
The `TimeZone.getTimeZoneIds` returns now a set instead of an array. The reason is the performance gain for such a relatively large list.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commenton ed my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings