### PR TITLE
Fix parsing issues for years with less than 4 digits

### DIFF
--- a/src/localDateTime.ts
+++ b/src/localDateTime.ts
@@ -65,7 +65,7 @@ export class LocalDateTime {
         });
 
         // eslint-disable-next-line max-len -- Regex literal cannot be split.
-        const matches = localDateTime.match(/(?<month>\d{2})\/(?<day>\d{2})\/(?<year>\d{4}), (?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})\.(?<fraction>\d{3})/);
+        const matches = localDateTime.match(/(?<month>\d{2})\/(?<day>\d{2})\/(?<year>\d{1,4}), (?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})\.(?<fraction>\d{3})/);
         // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain -- Safe assertion.
         const groups = matches?.groups!;
 

--- a/test/localDateTime.test.ts
+++ b/test/localDateTime.test.ts
@@ -30,10 +30,8 @@ describe('A value object representing a local date time', () => {
     });
 
     it('can be created from a native Date object', () => {
-        const date = new Date('August, 31 2015 23:15:30.123');
-        const localDateTime = LocalDateTime.fromNative(date);
-
-        expect(localDateTime.toString()).toBe('2015-08-31T23:15:30.123');
+        expect(LocalDateTime.fromNative(new Date(2015, 7, 31, 23, 15, 30, 123)).toString())
+            .toBe('2015-08-31T23:15:30.123');
     });
 
     it('can be created at the start of the day', () => {
@@ -119,6 +117,11 @@ describe('A value object representing a local date time', () => {
             // In October 2nd 2022 at 02:00:00, the time zone offset changed from +11:00 to +10:30
             timeZone: TimeZone.of('Australia/Lord_Howe'),
             expected: '2022-10-01T15:30:00Z',
+        },
+        {
+            input: LocalDateTime.of(LocalDate.of(1, 10, 2)),
+            timeZone: TimeZone.of('UTC'),
+            expected: '0001-10-02T00:00:00Z',
         },
     ])('should convert $input to $expected', ({input, timeZone, expected}) => {
         expect(input.toInstant(timeZone).toString()).toBe(expected);


### PR DESCRIPTION
## Summary
Fix parsing issues for years with less than 4 digits.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings